### PR TITLE
Adds tag filter support to resource EC2VPCEndpointServiceConfiguration

### DIFF
--- a/resources/ec2-vpc-endpoint-service-configurations.go
+++ b/resources/ec2-vpc-endpoint-service-configurations.go
@@ -11,6 +11,7 @@ type EC2VPCEndpointServiceConfiguration struct {
 	svc  *ec2.EC2
 	id   *string
 	name *string
+	tags []*ec2.Tag
 }
 
 func init() {
@@ -36,6 +37,7 @@ func ListEC2VPCEndpointServiceConfigurations(sess *session.Session) ([]Resource,
 				svc:  svc,
 				id:   serviceConfig.ServiceId,
 				name: serviceConfig.ServiceName,
+				tags: serviceConfig.Tags,
 			})
 		}
 
@@ -63,6 +65,9 @@ func (e *EC2VPCEndpointServiceConfiguration) Remove() error {
 
 func (e *EC2VPCEndpointServiceConfiguration) Properties() types.Properties {
 	properties := types.NewProperties()
+	for _, tagValue := range e.tags {
+		properties.SetTag(tagValue.Key, tagValue.Value)
+	}
 	properties.Set("Name", e.name)
 	return properties
 }


### PR DESCRIPTION
What we have done
--

We have a teardown use-case that needs to step over a particular EC2VPCEndpointServiceConfiguration that has the tag allow_delete set to false:

```yaml
      EC2VPCEndpointServiceConfiguration:
        - property: tag:allow_delete
          value: false
```

So we have added this configuration to the resource.

References
--

1. Similar to work done by @sjpalf here https://github.com/rebuy-de/aws-nuke/pull/855

Evidence of work
--

Running the command dist/aws-nuke  --config nuke-config.yml --quiet --target EC2VPCEndpointServiceConfiguration with the filter commented out from our config gives us:

```
eu-west-2 - EC2VPCEndpointServiceConfiguration - vpce-svc-<redacted> - [Name: com.amazonaws.vpce.eu-west-2.vpce-svc-<redacted>, tag:Name: <redacted>g, tag:allow_delete: false, tag:auth_enabled: true, tag:component: <redacted>, tag:component_root: core, tag:environment: <redacted>, tag:managed_by: terragrunt, tag:ssl_enabled: true, tag:strict_auth_enabled: true, tag:team: <redacted>] - would remove
Scan complete: 1 total, 1 nukeable, 0 filtered.
````

With the filter present in our config we get:

```
Scan complete: 1 total, 0 nukeable, 1 filtered.
```

This matches our expectations

Risks
--

I've not worked on this repo before and I'm not a regular Go-bot so my Go code might be suboptimal